### PR TITLE
Fix typo in README.md on HapticsType

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ flutter pub add haptic_feedback
 ```dart
 final canVibrate = await Haptics.canVibrate;
 
-await Haptics.vibrate(HapticType.success);
-await Haptics.vibrate(HapticType.warning);
-await Haptics.vibrate(HapticType.error);
+await Haptics.vibrate(HapticsType.success);
+await Haptics.vibrate(HapticsType.warning);
+await Haptics.vibrate(HapticsType.error);
 
-await Haptics.vibrate(HapticType.light);
-await Haptics.vibrate(HapticType.medium);
-await Haptics.vibrate(HapticType.heavy);
+await Haptics.vibrate(HapticsType.light);
+await Haptics.vibrate(HapticsType.medium);
+await Haptics.vibrate(HapticsType.heavy);
 
-await Haptics.vibrate(HapticType.rigid);
-await Haptics.vibrate(HapticType.soft);
+await Haptics.vibrate(HapticsType.rigid);
+await Haptics.vibrate(HapticsType.soft);
 
-await Haptics.vibrate(HapticType.selection);
+await Haptics.vibrate(HapticsType.selection);
 ```


### PR DESCRIPTION
Hi, I just fixed the typo in README.md from `HapticType` to Haptic`s`Type