### PR TITLE
fix(ios): link FlutterFramework in SPM Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4+4
+
+* Fix iOS Swift Package Manager build: link `FlutterFramework` in `Package.swift` (resolves undefined symbols `FlutterMethodChannel`, `FlutterMethodNotImplemented` when using Flutter SPM).
+
 ## 0.6.4+3
 
 * Update pub.dev topic.

--- a/ios/haptic_feedback/Package.swift
+++ b/ios/haptic_feedback/Package.swift
@@ -12,11 +12,15 @@ let package = Package(
         // Match Flutter's generated SwiftPM expectation (`haptic-feedback`).
         .library(name: "haptic-feedback", type: .dynamic, targets: ["haptic_feedback"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "haptic_feedback",
-            dependencies: []
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
         )
     ]
 )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - vibration
   - vibrate
 
-version: 0.6.4+3
+version: 0.6.4+4
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Resolves undefined FlutterMethodChannel / FlutterMethodNotImplemented symbols when building with Flutter Swift Package Manager enabled.